### PR TITLE
chore(ci): bump deprecated Node 16/20 actions to Node 24 (PLA-20 follow-up)

### DIFF
--- a/.github/workflows/post-install.yml
+++ b/.github/workflows/post-install.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -24,7 +24,7 @@ jobs:
           rm .github/workflows/post-install.yml
 
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Post installation operations"
           tagging_message: 'v0.1.0'


### PR DESCRIPTION
## Context
Follow-up to **PLA-20** (Node 20 -> 24 GitHub Actions). A full org `origin/HEAD` scan found this repo’s **workflow files** still referenced Node 16/20 actions. This PR bumps them to their latest Node 24-compatible major.
## Bumps
- `actions/checkout@v4` -> `actions/checkout@v6`
- `stefanzweifel/git-auto-commit-action@v5` -> `stefanzweifel/git-auto-commit-action@v7`
## Not included
Actions with no clean Node 24 path (archived, still-node20, or breaking majors like `golangci-lint-action`, `release-please-action`, `slack-github-action`) were intentionally left out and are tracked in **PLA-133**.
